### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ license = "MIT OR Apache-2.0"
 keywords = ["numerics", "mathematics"]
 
 [dependencies]
-fixed = "1"
-typenum = "1"
-num-traits = { version = "0.2", default-features = false, features = ["i128"] }
+fixed = "1.24.0"
+typenum = "1.17.0"
+num-traits = { version = "0.2.17", default-features = false, features = ["i128"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,6 @@ impl_fixed_pow!(FixedU128, LeEqU128, U127);
 trait Helper {
     const NUM_BITS: u32;
     fn is_positive(self) -> bool;
-    fn is_zero(self) -> bool;
     fn is_one(self) -> bool;
     fn one() -> Self;
     fn neg(self) -> Self;
@@ -252,9 +251,6 @@ macro_rules! impl_sign_helper {
             const NUM_BITS: u32 = <Self as Fixed>::INT_NBITS + <Self as Fixed>::FRAC_NBITS;
             fn is_positive(self) -> bool {
                 $fixed::is_positive(self)
-            }
-            fn is_zero(self) -> bool {
-                self.to_bits() == 0
             }
             fn is_one(self) -> bool {
                 <LeEq<Frac, $le_eq_one>>::BOOL && self.to_bits() == 1 << Frac::U32
@@ -279,9 +275,6 @@ macro_rules! impl_sign_helper {
             const NUM_BITS: u32 = <Self as Fixed>::INT_NBITS + <Self as Fixed>::FRAC_NBITS;
             fn is_positive(self) -> bool {
                 self != Self::from_bits(0)
-            }
-            fn is_zero(self) -> bool {
-                self.to_bits() == 0
             }
             fn is_one(self) -> bool {
                 <LeEq<Frac, $le_eq_one>>::BOOL && self.to_bits() == 1 << Frac::U32


### PR DESCRIPTION
Just a small PR to update dependencies as I noticed it doesn't compile with latest fixed.

# Changes
* Update fixed to `1.24.0`
* Update typenum to `1.17.0`
* Update num-traits to `0.2.17`
* Remove `is_zero()` method (now supported by `Fixed`)

Ran the tests and benchmarks and all good.